### PR TITLE
Fix child concatenation in <Comment />

### DIFF
--- a/src/jsx.js
+++ b/src/jsx.js
@@ -36,10 +36,10 @@ exports.Raw = ({ html }) => ({ type: "raw", value: html });
 exports.DOCTYPE = () => ({ type: "doctype", name: "html" });
 
 /**
- * @param {{children: string[]}} props
+ * @param {{children: import('hast').Text[]}} props
  * @returns {import('hast').Comment}
  */
 exports.Comment = ({ children }) => ({
   type: "comment",
-  value: children.join(""),
+  value: children.map((child) => child.value).join(""),
 });


### PR DESCRIPTION
Currently, when I use the `<Comment />` component, the output looks like:

```html
<!--[object Object]-->
```

It appears that `children` is actually an array of Text nodes of shape `{ type: "text", value: "..." }`. This PR updates the `<Comment />` component accordingly.